### PR TITLE
HomeView, ProjectDetailView에서 가능한 화면 플로우 구현 

### DIFF
--- a/Caladium/Caladium/App/CaladiumApp.swift
+++ b/Caladium/Caladium/App/CaladiumApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct CaladiumApp: App {
+    let coreDataService = CoreDataService()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
@@ -16,6 +18,7 @@ struct CaladiumApp: App {
                     \.managedObjectContext,
                     CoreDataManager.shared.mainContext
                 )
+                .environment(\.coreDataService, coreDataService) // 동일한 인스턴스 공유
         }
     }
 }

--- a/Caladium/Caladium/App/ContentView.swift
+++ b/Caladium/Caladium/App/ContentView.swift
@@ -27,12 +27,12 @@ struct ContentView: View {
         }
         .alert(item: $coordinator.showingAlert) { alertType in
             switch alertType {
-            case .cameraEnvironmentCheck(let onConfirm):
+            case .cameraEnvironmentCheck(let onConfirm, let onCancel):
                 return Alert(
                     title: Text("촬영 환경 확인"),
                     message: Text("주위 환경을 확인해주세요."),
                     primaryButton: .default(Text("확인"), action: onConfirm),
-                    secondaryButton: .cancel()
+                    secondaryButton: .cancel(Text("취소"), action: onCancel)
                 )
                 
             case .confirmDelete(let count, let onConfirm):
@@ -70,7 +70,7 @@ struct ContentView: View {
     @ViewBuilder
     private var rootView: some View {
         if coordinator.isOnboardingComplete {
-            HomeView()
+            HomeView(vm:HomeViewModel(coordinator: coordinator))
         } else {
             OnboardingContainerView()
         }
@@ -79,11 +79,8 @@ struct ContentView: View {
     @ViewBuilder
     private func routeView(for route: AppRoute) -> some View {
         switch route {
-        case .home(let category):
-            HomeView()
-                .onAppear {
-                    coordinator.changeCategory(to: category)
-                }
+        case .home:
+            HomeView(vm:HomeViewModel(coordinator: coordinator))
         case .projectDetail(let project):
             ProjectDetailView(project: project)
             
@@ -189,143 +186,6 @@ struct OnboardingContainerView: View {
             }
         }
         .padding()
-    }
-}
-
-// MARK: - Home View
-struct HomeView: View {
-    @EnvironmentObject var coordinator: AppCoordinator
-    @Environment(\.managedObjectContext) private var context
-    
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Project.updatedDate, ascending: false)],
-        animation: .default)
-    private var allProjects: FetchedResults<Project>
-    
-    // 현재 선택된 카테고리의 프로젝트들
-    private var filteredProjects: [Project] {
-        allProjects.filter { $0.categoryEnum == coordinator.currentCategory }
-    }
-    
-    var body: some View {
-        VStack {
-            // 카테고리 선택
-            categorySelector
-            
-            // 메인 컨텐츠
-            if filteredProjects.isEmpty {
-                emptyStateView
-            } else {
-                projectGridView
-            }
-            
-            Spacer()
-        }
-        .navigationTitle(coordinator.currentCategory.displayName)
-        .navigationBarTitleDisplayMode(.large)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                if coordinator.homeEditMode == .normal {
-                    Menu {
-                        Button("새 프로젝트", systemImage: "plus") {
-                            coordinator.startNewProject()
-                        }
-                        Button("편집", systemImage: "pencil") {
-                            coordinator.startDeleteMode()
-                        }
-                        Button("이동", systemImage: "arrow.right") {
-                            coordinator.startMoveMode()
-                        }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                    }
-                } else {
-                    HStack {
-                        Button("취소") {
-                            coordinator.cancelEditMode()
-                        }
-                        
-                        if case .delete(let selected) = coordinator.homeEditMode, !selected.isEmpty {
-                            Button("삭제") {
-                                coordinator.deleteSelectedProjects()
-                            }
-                            .foregroundColor(.red)
-                        }
-                        
-                        if case .move(let selected) = coordinator.homeEditMode, !selected.isEmpty {
-                            Button("이동") {
-                                coordinator.moveSelectedProjects()
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-    
-    private var categorySelector: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 15) {
-                ForEach(Category.allCases, id: \.self) { category in
-                    Button {
-                        coordinator.changeCategory(to: category)
-                    } label: {
-                        VStack {
-                            Image(systemName: category.icon)
-                                .font(.title2)
-                            Text(category.displayName)
-                                .font(.caption)
-                        }
-                        .foregroundColor(coordinator.currentCategory == category ? .white : .primary)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(coordinator.currentCategory == category ? Color.blue : Color.gray.opacity(0.2))
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal)
-        }
-    }
-    
-    private var emptyStateView: some View {
-        VStack(spacing: 20) {
-            Image(systemName: coordinator.currentCategory.icon)
-                .font(.system(size: 60))
-                .foregroundColor(.gray)
-            
-            Text("아직 \(coordinator.currentCategory.displayName) 프로젝트가 없습니다")
-                .font(.title3)
-                .multilineTextAlignment(.center)
-            
-            Text("새로운 식물을 추가해보세요!")
-                .foregroundColor(.secondary)
-            
-            Button {
-                coordinator.startNewProject()
-            } label: {
-                Label("첫 프로젝트 시작하기", systemImage: "plus")
-            }
-            .buttonStyle(.borderedProminent)
-        }
-        .padding()
-    }
-    
-    private var projectGridView: some View {
-        ScrollView {
-            LazyVGrid(columns: [
-                GridItem(.flexible()),
-                GridItem(.flexible())
-            ], spacing: 15) {
-                ForEach(filteredProjects, id: \.id) { project in
-                    ProjectCardView(project: project)
-                }
-            }
-            .padding(.horizontal)
-        }
     }
 }
 

--- a/Caladium/Caladium/App/ContentView.swift
+++ b/Caladium/Caladium/App/ContentView.swift
@@ -25,6 +25,7 @@ struct ContentView: View {
         .fullScreenCover(item: $coordinator.presentedFullScreen) { route in
             routeView(for: route)
         }
+        .tint(.green500)
     }
     
     @ViewBuilder
@@ -32,7 +33,7 @@ struct ContentView: View {
         if coordinator.isOnboardingComplete {
             HomeView(vm:HomeViewModel(coordinator: coordinator))
         } else {
-            OnboardingContainerView()
+            OnboardingContainerView(coordinator: coordinator)
         }
     }
     

--- a/Caladium/Caladium/App/ContentView.swift
+++ b/Caladium/Caladium/App/ContentView.swift
@@ -15,9 +15,9 @@ struct ContentView: View {
     var body: some View {
         NavigationStack(path: $coordinator.path) {
             rootView
-        }
-        .navigationDestination(for: AppRoute.self) { route in
-            routeView(for: route)
+                .navigationDestination(for: AppRoute.self) { route in
+                    routeView(for: route)
+                }
         }
         .sheet(item: $coordinator.presentedSheet) { route in
             routeView(for: route)
@@ -25,46 +25,6 @@ struct ContentView: View {
         .fullScreenCover(item: $coordinator.presentedFullScreen) { route in
             routeView(for: route)
         }
-        .alert(item: $coordinator.showingAlert) { alertType in
-            switch alertType {
-            case .cameraEnvironmentCheck(let onConfirm, let onCancel):
-                return Alert(
-                    title: Text("촬영 환경 확인"),
-                    message: Text("주위 환경을 확인해주세요."),
-                    primaryButton: .default(Text("확인"), action: onConfirm),
-                    secondaryButton: .cancel(Text("취소"), action: onCancel)
-                )
-                
-            case .confirmDelete(let count, let onConfirm):
-                return Alert(
-                    title: Text("삭제 확인"),
-                    message: Text("\(count)개의 프로젝트를 정말 삭제하시겠습니까?"),
-                    primaryButton: .destructive(Text("삭제"), action: onConfirm),
-                    secondaryButton: .cancel()
-                )
-                
-            case .selectMoveCategory(_, _):
-                return Alert(title: Text("카테고리 선택"))
-            }
-        }
-        .confirmationDialog(
-            "카테고리 선택",
-            isPresented: .constant(coordinator.showingAlert?.id == "select_category"),
-            presenting: coordinator.showingAlert
-        ) { alertType in
-            if case .selectMoveCategory(_, let onSelect) = alertType {
-                ForEach(Category.allCases, id: \.self) { category in
-                    Button(category.rawValue) {
-                        onSelect(category)
-                        coordinator.dismissAlert()
-                    }
-                }
-                Button("취소", role: .cancel) {
-                    coordinator.dismissAlert()
-                }
-            }
-        }
-        .environmentObject(coordinator)
     }
     
     @ViewBuilder
@@ -81,14 +41,15 @@ struct ContentView: View {
         switch route {
         case .home:
             HomeView(vm:HomeViewModel(coordinator: coordinator))
+            
         case .projectDetail(let project):
-            ProjectDetailView(project: project)
+            ProjectDetailView(vm:ProjectDetailViewModel(coordinator: coordinator), project: project)
             
         case .photoDetail(let photo, let project):
             PhotoDetailView(photo: photo, project: project)
             
         case .camera(let context):
-            CameraView(context: context)
+            CameraView(vm: CameraViewModel(coordinator: coordinator), context: context)
             
         case .photoConfirm(let image, let context):
             PhotoConfirmView(image: image, context: context)
@@ -103,276 +64,7 @@ struct ContentView: View {
     
 }
 
-// MARK: - Onboarding Views
-struct OnboardingContainerView: View {
-    @EnvironmentObject var coordinator: AppCoordinator
-    @State private var currentStep: OnboardingStep = .welcome
-    
-    var body: some View {
-        VStack(spacing: 20) {
-            Text("온보딩 - \(currentStep.rawValue + 1)/\(OnboardingStep.allCases.count)")
-                .font(.title2)
-                .bold()
-            
-            switch currentStep {
-            case .welcome:
-                VStack(spacing: 15) {
-                    Text("🌱 Caladium에 오신 것을 환영합니다!")
-                        .font(.title)
-                    Text("식물의 성장을 기록하고 타임랩스 영상을 만들어보세요")
-                        .foregroundColor(.secondary)
-                }
-                
-            case .features:
-                VStack(spacing: 15) {
-                    Text("✨ 주요 기능")
-                        .font(.title)
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text("📸 정기적인 사진 촬영")
-                        Text("🎬 타임랩스 영상 제작")
-                        Text("🗂 카테고리별 정리")
-                        Text("📈 성장 과정 추적")
-                    }
-                }
-                
-            case .permissions:
-                VStack(spacing: 15) {
-                    Text("📷 권한 설정")
-                        .font(.title)
-                    Text("카메라 권한이 필요합니다")
-                        .foregroundColor(.secondary)
-                    Button("권한 허용하기") {
-                        // 실제로는 권한 요청 로직
-                        currentStep = .complete
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-                
-            case .complete:
-                VStack(spacing: 15) {
-                    Text("🎉 설정 완료!")
-                        .font(.title)
-                    Text("이제 첫 번째 식물을 추가해보세요")
-                        .foregroundColor(.secondary)
-                }
-            }
-            
-            Spacer()
-            
-            HStack {
-                if currentStep != .welcome {
-                    Button("이전") {
-                        if let previous = currentStep.previous {
-                            currentStep = previous
-                        }
-                    }
-                }
-                
-                Spacer()
-                
-                if currentStep == .complete {
-                    Button("시작하기") {
-                        coordinator.completeOnboarding()
-                    }
-                    .buttonStyle(.borderedProminent)
-                } else {
-                    Button("다음") {
-                        if let next = currentStep.next {
-                            currentStep = next
-                        }
-                    }
-                    .buttonStyle(.borderedProminent)
-                }
-            }
-        }
-        .padding()
-    }
-}
 
-// MARK: - Project Card View
-struct ProjectCardView: View {
-    let project: Project
-    @EnvironmentObject var coordinator: AppCoordinator
-    
-    var body: some View {
-        Button {
-            if coordinator.homeEditMode == .normal {
-                coordinator.navigate(to: .projectDetail(project))
-            } else {
-                toggleSelection()
-            }
-        } label: {
-            VStack(spacing: 8) {
-                // 썸네일 이미지 (임시)
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.3))
-                    .aspectRatio(4/3, contentMode: .fit)
-                    .overlay {
-                        VStack {
-                            Image(systemName: project.categoryEnum.icon)
-                                .font(.title)
-                            Text("\(project.photoCount)장")
-                                .font(.caption)
-                        }
-                        .foregroundColor(.gray)
-                    }
-                
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("프로젝트 #\(project.id?.uuidString.prefix(8) ?? "Unknown")")
-                        .font(.caption)
-                        .foregroundColor(.primary)
-                    
-                    Text(project.createdDate?.formatted(date: .abbreviated, time: .omitted) ?? "")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .padding(12)
-            .background(Color.gray.opacity(0.1))
-            .clipShape(RoundedRectangle(cornerRadius: 12))
-            .overlay {
-                if isSelected {
-                    RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.blue, lineWidth: 2)
-                }
-            }
-        }
-        .buttonStyle(.plain)
-    }
-    
-    private var isSelected: Bool {
-        switch coordinator.homeEditMode {
-        case .delete(let selected), .move(let selected):
-            return selected.contains(project)
-        case .normal:
-            return false
-        }
-    }
-    
-    private func toggleSelection() {
-        switch coordinator.homeEditMode {
-        case .delete(var selected):
-            if selected.contains(project) {
-                selected.remove(project)
-            } else {
-                selected.insert(project)
-            }
-            coordinator.homeEditMode = .delete(selectedProject: selected)
-            
-        case .move(var selected):
-            if selected.contains(project) {
-                selected.remove(project)
-            } else {
-                selected.insert(project)
-            }
-            coordinator.homeEditMode = .move(selectedProject: selected)
-            
-        case .normal:
-            break
-        }
-    }
-}
-
-// MARK: - Project Detail View
-struct ProjectDetailView: View {
-    let project: Project
-    @EnvironmentObject var coordinator: AppCoordinator
-    
-    @FetchRequest private var photos: FetchedResults<Photo>
-    
-    init(project: Project) {
-        self.project = project
-        self._photos = FetchRequest(
-            entity: Photo.entity(),
-            sortDescriptors: [NSSortDescriptor(keyPath: \Photo.capturedDate, ascending: true)],
-            predicate: NSPredicate(format: "project == %@", project)
-        )
-    }
-    
-    var body: some View {
-        ScrollView {
-            VStack(spacing: 20) {
-                // 프로젝트 정보
-                VStack(spacing: 10) {
-                    Text("📊 프로젝트 정보")
-                        .font(.title2)
-                        .bold()
-                    
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("카테고리: \(project.categoryEnum.displayName)")
-                        Text("생성일: \(project.createdDate?.formatted() ?? "")")
-                        Text("마지막 업데이트: \(project.updatedDate?.formatted() ?? "")")
-                        Text("사진 수: \(photos.count)장")
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
-                
-                // 액션 버튼들
-                VStack(spacing: 12) {
-                    Button {
-                        coordinator.addPhotoToProject(project)
-                    } label: {
-                        Label("사진 추가", systemImage: "camera")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    
-                    if photos.count >= 2 {
-                        Button {
-                            coordinator.startVideoCreation(for: project)
-                        } label: {
-                            Label("영상 만들기", systemImage: "video")
-                                .frame(maxWidth: .infinity)
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                }
-                
-                // 사진 그리드
-                if !photos.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("📷 사진들")
-                            .font(.title2)
-                            .bold()
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        LazyVGrid(columns: [
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible())
-                        ], spacing: 10) {
-                            ForEach(photos, id: \.id) { photo in
-                                Button {
-                                    coordinator.navigate(to: .photoDetail(photo, project))
-                                } label: {
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color.gray.opacity(0.3))
-                                        .aspectRatio(1, contentMode: .fit)
-                                        .overlay {
-                                            VStack {
-                                                Image(systemName: "photo")
-                                                Text(photo.capturedDate?.formatted(date: .abbreviated, time: .omitted) ?? "")
-                                                    .font(.caption2)
-                                            }
-                                            .foregroundColor(.gray)
-                                        }
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                    }
-                }
-            }
-            .padding()
-        }
-        .navigationTitle("프로젝트 상세")
-        .navigationBarTitleDisplayMode(.inline)
-    }
-}
 
 // MARK: - Photo Detail View
 struct PhotoDetailView: View {
@@ -428,73 +120,6 @@ struct PhotoDetailView: View {
     }
 }
 
-// MARK: - Camera View
-struct CameraView: View {
-    let context: CameraContext
-    @EnvironmentObject var coordinator: AppCoordinator
-    
-    var body: some View {
-        VStack {
-            Spacer()
-            
-            VStack(spacing: 20) {
-                Text("📷 카메라")
-                    .font(.largeTitle)
-                    .bold()
-                
-                Text(contextDescription)
-                    .foregroundColor(.secondary)
-                
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color.gray.opacity(0.3))
-                    .aspectRatio(4/3, contentMode: .fit)
-                    .overlay {
-                        Text("카메라 뷰 영역")
-                            .foregroundColor(.gray)
-                    }
-            }
-            
-            Spacer()
-            
-            // 촬영 버튼
-            Button {
-                // 임시 이미지로 다음 단계로
-                let tempImage = UIImage(systemName: "photo") ?? UIImage()
-                coordinator.navigate(to: .photoConfirm(tempImage, context))
-            } label: {
-                Circle()
-                    .fill(Color.white)
-                    .frame(width: 80, height: 80)
-                    .overlay {
-                        Circle()
-                            .stroke(Color.black, lineWidth: 3)
-                            .frame(width: 70, height: 70)
-                    }
-            }
-            .padding(.bottom, 50)
-        }
-        .background(Color.black)
-        .foregroundColor(.white)
-        .navigationBarHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button("취소") {
-                    coordinator.dismissFullScreen()
-                }
-                .foregroundColor(.white)
-            }
-        }
-    }
-    
-    private var contextDescription: String {
-        switch context {
-        case .newProject:
-            return "새로운 식물의 첫 번째 사진을 찍어보세요"
-        case .existingProject(let project):
-            return "\(project.categoryEnum.displayName) 프로젝트에 사진을 추가합니다"
-        }
-    }
-}
 
 // MARK: - Photo Confirm View
 struct PhotoConfirmView: View {

--- a/Caladium/Caladium/CoreData/CoreDataManager.swift
+++ b/Caladium/Caladium/CoreData/CoreDataManager.swift
@@ -123,7 +123,7 @@ extension CoreDataManager {
                 project.updatedDate = Date().addingTimeInterval(-Double(i * 1800))
                 
                 // 각 프로젝트에 사진 몇 개 추가 (메타데이터만)
-                for j in 1...3 {
+                for j in 1...20 {
                     let photo = Photo(context: context)
                     photo.id = UUID()
                     photo.fileName = "preview_photo_\(i)_\(j).jpg"

--- a/Caladium/Caladium/CoreData/CoreDataManager.swift
+++ b/Caladium/Caladium/CoreData/CoreDataManager.swift
@@ -82,3 +82,61 @@ final class CoreDataManager {
         }
     }
 }
+
+
+extension CoreDataManager {
+    
+    // 프리뷰용 인메모리 컨테이너
+    static var preview: CoreDataManager = {
+        let manager = CoreDataManager()
+        
+        // 인메모리 스토어로 설정
+        let container = NSPersistentContainer(name: "Caladium")
+        container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        container.persistentStoreDescriptions.first?.type = NSInMemoryStoreType
+        
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Preview Core Data error: \(error)")
+            }
+        }
+        
+        manager.persistentContainer = container
+        
+        // 프리뷰용 샘플 데이터 생성
+        manager.generatePreviewData()
+        
+        return manager
+    }()
+    
+    // 프리뷰용 샘플 데이터 생성
+    private func generatePreviewData() {
+        let context = mainContext
+        
+        // 각 카테고리별로 프로젝트 생성
+        for category in Category.allCases {
+            for i in 1...10 {
+                let project = Project(context: context, category: category)
+                project.id = UUID()
+                project.category = category.rawValue
+                project.createdDate = Date().addingTimeInterval(-Double(i * 3600))
+                project.updatedDate = Date().addingTimeInterval(-Double(i * 1800))
+                
+                // 각 프로젝트에 사진 몇 개 추가 (메타데이터만)
+                for j in 1...3 {
+                    let photo = Photo(context: context)
+                    photo.id = UUID()
+                    photo.fileName = "preview_photo_\(i)_\(j).jpg"
+                    photo.capturedDate = Date().addingTimeInterval(-Double(j * 3600))
+                    photo.project = project
+                }
+            }
+        }
+        
+        do {
+            try context.save()
+        } catch {
+            print("Preview data creation failed: \(error)")
+        }
+    }
+}

--- a/Caladium/Caladium/Navigation/AppCoordinator.swift
+++ b/Caladium/Caladium/Navigation/AppCoordinator.swift
@@ -66,9 +66,18 @@ final class AppCoordinator: ObservableObject {
     }
     
     func startNewProject() {
-        showingAlert = .cameraEnvironmentCheck {
-            self.presentFullScreen(.camera(.newProject))
-        }
+        // 먼저 카메라 풀스크린으로 띄우기
+        presentFullScreen(.camera(.newProject))
+        
+        // 카메라 화면에 Alert 띄우기
+        showingAlert = .cameraEnvironmentCheck(onConfirm: {
+            // 확인: Alert 만 닫기( 카메라 창 유지)
+            self.dismissAlert()
+        }, onCancel: {
+            // 취소 : Alert 먼저 닫고 + 카메라 화면 닫기
+            self.dismissAlert()
+            self.dismissFullScreen()
+        })
     }
     
     func startDeleteMode() {
@@ -161,7 +170,7 @@ final class AppCoordinator: ObservableObject {
 }
 
 enum AlertType: Identifiable {
-    case cameraEnvironmentCheck(onConfirm: () -> Void)
+    case cameraEnvironmentCheck(onConfirm: () -> Void, onCancel: () -> Void)
     case confirmDelete(count: Int, onConfirm: () -> Void)
     case selectMoveCategory(projects: Set<Project>, onSelect: (
     Category) -> Void)

--- a/Caladium/Caladium/Navigation/AppCoordinator.swift
+++ b/Caladium/Caladium/Navigation/AppCoordinator.swift
@@ -18,7 +18,6 @@ final class AppCoordinator: ObservableObject {
     // App State
     @AppStorage("onboarding_completed") var isOnboardingComplete: Bool = false
     @AppStorage("last_selected_category") var currentCategory: Category = .garden
-    @Published var homeEditMode: HomeEditMode = .normal
     
     // Alert States
     @Published var showingAlert: AlertType?
@@ -55,59 +54,14 @@ final class AppCoordinator: ObservableObject {
         presentedFullScreen = nil
     }
     
-    // MARK: - 홈 화면 액션들
+    // MARK: - 카테고리 변경
     func changeCategory(to category: Category) {
         currentCategory = category
-        homeEditMode = .normal  // 카테고리 변경시 편집모드 해제
     }
+    
     // MARK: - 온보딩 완료
     func completeOnboarding() {
         isOnboardingComplete = true  // @AppStorage가 자동으로 저장
-    }
-    
-    func startNewProject() {
-        // 먼저 카메라 풀스크린으로 띄우기
-        presentFullScreen(.camera(.newProject))
-        
-        // 카메라 화면에 Alert 띄우기
-        showingAlert = .cameraEnvironmentCheck(onConfirm: {
-            // 확인: Alert 만 닫기( 카메라 창 유지)
-            self.dismissAlert()
-        }, onCancel: {
-            // 취소 : Alert 먼저 닫고 + 카메라 화면 닫기
-            self.dismissAlert()
-            self.dismissFullScreen()
-        })
-    }
-    
-    func startDeleteMode() {
-        homeEditMode = .delete(selectedProject: [])
-    }
-    
-    func startMoveMode() {
-        homeEditMode = .move(selectedProject: [])
-    }
-    
-    func cancelEditMode() {
-        homeEditMode = .normal
-    }
-    
-    func deleteSelectedProjects() {
-        guard case .delete(let projects) = homeEditMode else { return }
-        
-        showingAlert = .confirmDelete(count: projects.count) {
-            // CoreData 삭제 로직
-            self.homeEditMode = .normal
-        }
-    }
-    
-    func moveSelectedProjects() {
-        guard case .move(let projects) = homeEditMode else { return }
-        
-        showingAlert = .selectMoveCategory(projects: projects) { category in
-            // 카테고리 이동 로직
-            self.homeEditMode = .normal
-        }
     }
     
     // MARK: - 촬영 플로우

--- a/Caladium/Caladium/Navigation/AppRoute.swift
+++ b/Caladium/Caladium/Navigation/AppRoute.swift
@@ -84,3 +84,9 @@ enum HomeEditMode : Hashable{
     case delete(selectedProject: Set<Project>)
     case move(selectedProject: Set<Project>)
 }
+
+enum ProjectEditMode : Hashable{
+    case normal
+    case delete(selectedPhoto: Set<Photo>)
+    case makeVideo(selectedPhoto: Set<Photo>)
+}

--- a/Caladium/Caladium/Navigation/AppRoute.swift
+++ b/Caladium/Caladium/Navigation/AppRoute.swift
@@ -10,7 +10,7 @@ import UIKit
 
 enum AppRoute: Hashable, Identifiable {
     // 메인 앱 플로우
-    case home(category: Category)
+    case home
     case projectDetail(Project)
     case photoDetail(Photo, Project)
     
@@ -25,8 +25,8 @@ enum AppRoute: Hashable, Identifiable {
     // Identifiable 구현
     var id: String {
         switch self {
-        case .home(let category):
-            return "home_\(category.rawValue)"
+        case .home:
+            return "home"
         case .projectDetail(let project):
             return "project_\(project.id ?? UUID())"
         case .photoDetail(let photo, _):

--- a/Caladium/Caladium/Services/CoreDataService.swift
+++ b/Caladium/Caladium/Services/CoreDataService.swift
@@ -11,6 +11,7 @@ import UIKit
 
 final class CoreDataService {
     
+    // MARK: 의존성 주입시 각 ViewModel에서 동일한 인스턴스 공유하도록 설계
     let context: NSManagedObjectContext
     let coreDataManager: CoreDataManager
     

--- a/Caladium/Caladium/Services/CoreDataService.swift
+++ b/Caladium/Caladium/Services/CoreDataService.swift
@@ -245,11 +245,23 @@ extension CoreDataService {
             }
         }
         
-        // 첫 번째 프로젝트에 사진 추가
-        if let firstProject = try? fetchAllProjects().first {
-            for _ in 1...5 {
-                let mockImage = UIImage(systemName: "photo") ?? UIImage()
-                try? createPhoto(image: mockImage, project: firstProject)
+        // 모든 프로젝트에 사진 추가
+        if let allProjects = try? fetchAllProjects() {
+            for project in allProjects {
+                // 각 프로젝트마다 3-7개의 랜덤한 수의 사진 추가
+                let photoCount = Int.random(in: 3...7)
+                
+                for i in 1...photoCount {
+                    // 다양한 색상의 샘플 이미지 생성
+                    let mockImage = UIImage(systemName: "photo") ?? UIImage()
+
+                    do {
+                        try createPhoto(image: mockImage, project: project)
+                        print("Added photo \(i) to project \(project.categoryEnum.rawValue)")
+                    } catch {
+                        print("Failed to create photo for project \(project.categoryEnum.rawValue): \(error)")
+                    }
+                }
             }
         }
     }

--- a/Caladium/Caladium/ViewModels/CameraViewModel.swift
+++ b/Caladium/Caladium/ViewModels/CameraViewModel.swift
@@ -5,4 +5,18 @@
 //  Created by yoomin on 6/9/25.
 //
 
-import Foundation
+import SwiftUI
+
+final class CameraViewModel: ObservableObject {
+    
+    private let coordinator: AppCoordinator
+    
+    init(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+    func cancel() {
+        coordinator.dismissFullScreen()
+    }
+    
+}

--- a/Caladium/Caladium/ViewModels/HomeViewModel.swift
+++ b/Caladium/Caladium/ViewModels/HomeViewModel.swift
@@ -153,3 +153,10 @@ final class HomeViewModel: ObservableObject {
     }
 
 }
+
+
+extension HomeViewModel {
+    func addMockData() {
+        coreDataService.createMockData()
+    }
+}

--- a/Caladium/Caladium/ViewModels/HomeViewModel.swift
+++ b/Caladium/Caladium/ViewModels/HomeViewModel.swift
@@ -13,10 +13,12 @@ final class HomeViewModel: ObservableObject {
     @Published var editMode: HomeEditMode = .normal
     
     private let coordinator: AppCoordinator
+    private let coreDataService: CoreDataService
     
     init(coordinator: AppCoordinator) {
         self.coordinator = coordinator
         self.currentCategory = coordinator.currentCategory
+        self.coreDataService = CoreDataService()
     }
     
     // MARK: - Category Navigation
@@ -45,11 +47,12 @@ final class HomeViewModel: ObservableObject {
     
     // MARK: -  Project Actions
     func startNewProject() {
-        coordinator.startNewProject()
+        coordinator.presentFullScreen(.camera(.newProject))
     }
     
-    func selectProject() {
+    func selectProject(selectedProject: Project) {
         // 선택한 프로젝트로 네비게이션
+        coordinator.navigate(to: .projectDetail(selectedProject))
     }
     
     // MARK: - Edit Mode
@@ -139,4 +142,14 @@ final class HomeViewModel: ObservableObject {
             return true
         }
     }
+    
+    var selectedProjectsCount: Int {
+        switch editMode {
+        case .delete(let projects), .move(let projects):
+            return projects.count
+        case .normal:
+            return 0
+        }
+    }
+
 }

--- a/Caladium/Caladium/ViewModels/HomeViewModel.swift
+++ b/Caladium/Caladium/ViewModels/HomeViewModel.swift
@@ -6,3 +6,137 @@
 //
 
 import Foundation
+
+final class HomeViewModel: ObservableObject {
+    
+    @Published var currentCategory: Category
+    @Published var editMode: HomeEditMode = .normal
+    
+    private let coordinator: AppCoordinator
+    
+    init(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+        self.currentCategory = coordinator.currentCategory
+    }
+    
+    // MARK: - Category Navigation
+    func previousCategory() {
+        let allCases = Category.allCases
+        if let currentIndex = allCases.firstIndex(of: currentCategory) {
+            let previousIndex = currentIndex > 0 ? currentIndex - 1 : allCases.count - 1
+            changeCategory(to: allCases[previousIndex])
+        }
+    }
+    
+    func nextCategory() {
+        let allCases = Category.allCases
+        if let currentIndex = allCases.firstIndex(of: currentCategory) {
+            let nextIndex = (currentIndex + 1) % allCases.count
+            changeCategory(to: allCases[nextIndex])
+        }
+    }
+    
+    private func changeCategory(to category: Category) {
+        currentCategory = category
+        coordinator.changeCategory(to: category)
+        // 카테고리 변경시 편집모드 해제
+        exitEditMode()
+    }
+    
+    // MARK: -  Project Actions
+    func startNewProject() {
+        coordinator.startNewProject()
+    }
+    
+    func selectProject() {
+        // 선택한 프로젝트로 네비게이션
+    }
+    
+    // MARK: - Edit Mode
+    func startDeleteMode() {
+        editMode = .delete(selectedProject: [])
+    }
+    
+    func startMoveMode() {
+        editMode = .move(selectedProject: [])
+    }
+    
+    func exitEditMode() {
+        editMode = .normal
+    }
+    
+    func toggleProjectSelection(_ project: Project) {
+        switch editMode {
+        case .delete(var selected):
+            if selected.contains(project) {
+                selected.remove(project)
+            } else {
+                selected.insert(project)
+            }
+            editMode = .delete(selectedProject: selected)
+        case .move(var selected):
+            if selected.contains(project) {
+                selected.remove(project)
+            } else {
+                selected.insert(project)
+            }
+            editMode = .move(selectedProject: selected)
+            
+        case .normal:
+            break
+        }
+    }
+    
+    // View에서 각 프로젝트 선택상태 표시할 때 사용
+    func isProjectSelected(_ project: Project) -> Bool {
+        switch editMode {
+        case .delete(let selected), .move(let selected):
+            return selected.contains(project)
+        case .normal:
+            return false
+        }
+    }
+    
+    // TODO: Coordinator에서 화면 전환 로직 제외한 편집 모드 or 삭제 관련 로직 모두 제거
+    func deleteSelectedProjects() {
+        guard case .delete(let projects) = editMode else { return }
+        
+        // Coordinator를 통해 Alert 표시 및 삭제 처리
+//        coordinator.showDeleteConfirmAlert(count: projects.count) {
+//            // 실제 삭제 로직 수행
+//            self.performDelete(projects: projects)
+//            self.exitEditMode()
+//        }
+    }
+    
+    func moveSelectedProjects() {
+        guard case .move(let projects) = editMode else { return }
+        
+        // Coordinator를 통해 카테고리 선택 Alert 표시
+//        coordinator.showMoveCategoryAlert(projects: projects) { category in
+//            // 실제 이동 로직 수행
+//            self.performMove(projects: projects, to: category)
+//            self.exitEditMode()
+//        }
+    }
+    
+    // MARK: - Private Methods
+    private func performDelete(projects: Set<Project>) {
+        // CoreData 삭제 로직
+        // TODO: 실제 Core Data 삭제 구현 / CoreDataService 주입
+    }
+    
+    private func performMove(projects: Set<Project>, to category: Category) {
+        // CoreData 카테고리 이동 로직
+        // TODO: 실제 Core Data 업데이트 구현 / CoreDataService 주입 
+    }
+    
+    var isEditMode: Bool {
+        switch editMode {
+        case .normal:
+            return false
+        case .delete, .move:
+            return true
+        }
+    }
+}

--- a/Caladium/Caladium/ViewModels/ProjectDetailViewModel.swift
+++ b/Caladium/Caladium/ViewModels/ProjectDetailViewModel.swift
@@ -6,3 +6,13 @@
 //
 
 import Foundation
+
+final class ProjectDetailViewModel: ObservableObject {
+    
+    private let coordinator: AppCoordinator
+    
+    init(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+    }
+    
+}

--- a/Caladium/Caladium/ViewModels/ProjectDetailViewModel.swift
+++ b/Caladium/Caladium/ViewModels/ProjectDetailViewModel.swift
@@ -9,10 +9,98 @@ import Foundation
 
 final class ProjectDetailViewModel: ObservableObject {
     
+    @Published var editMode: ProjectEditMode = .normal
+    
     private let coordinator: AppCoordinator
+    private let coreDataService: CoreDataService
+    // 사진 만들기 서비스
     
     init(coordinator: AppCoordinator) {
         self.coordinator = coordinator
+        self.coreDataService = CoreDataService()
     }
     
+    // 선택한 사진 상세뷰 네비게이션
+    func navigateToPhotoDetail(photo: Photo, project: Project) {
+        coordinator.navigate(to: .photoDetail(photo, project))
+    }
+    
+    // 새로운 사진 찍기
+    func addNewPhoto(currentProject: Project) {
+        coordinator.presentFullScreen(.camera(.existingProject(currentProject)))
+    }
+    
+    // 지우기 모드 들어가기 -> 사진선택 -> 취소 or 삭제
+    func startDeleteMode() {
+        editMode = .delete(selectedPhoto: [])
+    }
+    
+    // 영상 만들기 모드 들어가기 -> 사진선택 -> 취소 or 만들기
+    func startVideoMode() {
+        editMode = .makeVideo(selectedPhoto: [])
+    }
+    
+    func exitEditMode() {
+        editMode = .normal
+    }
+    
+    func togglePhotoSelection(_ photo: Photo) {
+        switch editMode {
+        case .delete(var selectedPhoto):
+            if selectedPhoto.contains(photo) {
+                selectedPhoto.remove(photo)
+            } else {
+                selectedPhoto.insert(photo)
+            }
+            editMode = .delete(selectedPhoto: selectedPhoto)
+        case .makeVideo(var selectedPhoto):
+            if selectedPhoto.contains(photo) {
+                selectedPhoto.remove(photo)
+            } else {
+                selectedPhoto.insert(photo)
+            }
+            editMode = .makeVideo(selectedPhoto: selectedPhoto)
+        case .normal:
+            break
+        }
+    }
+    
+    func isPhotoSelected(_ photo: Photo) -> Bool {
+        switch editMode {
+        case .delete(let selected), .makeVideo(let selected):
+            return selected.contains(photo)
+        case .normal:
+            return false
+        }
+    }
+    
+    // 선택된 사진들 삭제하기 로직
+    func deleteSelectedPhotos() {
+        guard case .delete(let selectedPhoto) = editMode else { return }
+    }
+    
+    
+    // 선택된 사진들로 영상 만들기 로직
+    func makeVideoSelectedPhotos() {
+        guard case .makeVideo(let selectedPhoto) = editMode else { return }
+    }
+    
+    var isEditMode: Bool {
+        switch editMode {
+        case .normal:
+            return false
+        case .delete, .makeVideo:
+            return true
+        }
+    }
+    
+    var selectedProjectsCount: Int {
+        switch editMode {
+        case .delete(let photos), .makeVideo(let photos):
+            return photos.count
+        case .normal:
+            return 0
+        }
+    }
+
 }

--- a/Caladium/Caladium/Views/Componenets/AsyncPhotoImage.swift
+++ b/Caladium/Caladium/Views/Componenets/AsyncPhotoImage.swift
@@ -1,0 +1,77 @@
+//
+//  AsyncPhotoImage.swift
+//  Caladium
+//
+//  Created by 이종선 on 6/28/25.
+//
+
+import SwiftUI
+
+// MARK: - Environment Key for CoreDataService
+struct CoreDataServiceKey: EnvironmentKey {
+    static let defaultValue = CoreDataService()
+}
+
+extension EnvironmentValues {
+    var coreDataService: CoreDataService {
+        get { self[CoreDataServiceKey.self] }
+        set { self[CoreDataServiceKey.self] = newValue }
+    }
+}
+
+// MARK: - AsyncImage Component
+struct AsyncPhotoImage: View {
+    let photo: Photo
+    @State private var image: UIImage?
+    @State private var isLoading = true
+    
+    @Environment(\.coreDataService) private var coreDataService
+    
+    var body: some View {
+        Group {
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else if isLoading {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.2))
+                    .overlay(
+                        ProgressView()
+                            .scaleEffect(0.5)
+                    )
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .overlay(
+                        Image(systemName: "photo")
+                            .foregroundColor(.gray)
+                    )
+            }
+        }
+        .onAppear {
+            loadImage()
+        }
+    }
+    
+    private func loadImage() {
+        guard let fileName = photo.fileName else {
+            isLoading = false
+            return
+        }
+        
+        Task {
+            let loadedImage = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let image = coreDataService.loadImageFromFile(fileName: fileName)
+                    continuation.resume(returning: image)
+                }
+            }
+            
+            await MainActor.run {
+                self.image = loadedImage
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/Caladium/Caladium/Views/Screen/CameraView.swift
+++ b/Caladium/Caladium/Views/Screen/CameraView.swift
@@ -1,0 +1,87 @@
+//
+//  CameraView.swift
+//  Caladium
+//
+//  Created by 이종선 on 6/22/25.
+//
+
+import SwiftUI
+
+// MARK: - Camera View
+struct CameraView: View {
+    @StateObject private var vm: CameraViewModel
+    let context: CameraContext
+    
+    init(vm: CameraViewModel, context: CameraContext) {
+        self._vm = StateObject(wrappedValue: vm)
+        self.context = context
+    }
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            VStack(spacing: 20) {
+                Text("📷 카메라")
+                    .font(.largeTitle)
+                    .bold()
+                
+                Text(contextDescription)
+                    .foregroundColor(.secondary)
+                
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.gray.opacity(0.3))
+                    .aspectRatio(4/3, contentMode: .fit)
+                    .overlay {
+                        Text("카메라 뷰 영역")
+                            .foregroundColor(.gray)
+                    }
+            }
+            
+            Spacer()
+            
+            // 촬영 버튼
+            Button {
+                // 임시 이미지로 다음 단계로
+                let tempImage = UIImage(systemName: "photo") ?? UIImage()
+
+            } label: {
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 80, height: 80)
+                    .overlay {
+                        Circle()
+                            .stroke(Color.black, lineWidth: 3)
+                            .frame(width: 70, height: 70)
+                    }
+            }
+            .padding(.bottom, 50)
+        }
+        .background(Color.black)
+        .foregroundColor(.white)
+        .navigationBarHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .bottomBar) {
+                Button("취소") {
+                    vm.cancel()
+                }
+                .font(.headline)
+                .foregroundColor(.white)
+            }
+        }
+    }
+    
+    private var contextDescription: String {
+        switch context {
+        case .newProject:
+            return "새로운 식물의 첫 번째 사진을 찍어보세요"
+        case .existingProject(let project):
+            return "\(project.categoryEnum.displayName) 프로젝트에 사진을 추가합니다"
+        }
+    }
+}
+
+
+#Preview {
+    CameraView(vm: CameraViewModel(coordinator: AppCoordinator()), context: .newProject)
+}

--- a/Caladium/Caladium/Views/Screen/HomeView.swift
+++ b/Caladium/Caladium/Views/Screen/HomeView.swift
@@ -1,0 +1,162 @@
+//
+//  HomeView.swift
+//  Caladium
+//
+//  Created by 이종선 on 6/20/25.
+//
+
+import SwiftUI
+
+struct HomeView: View {
+    @StateObject private var vm: HomeViewModel
+    
+    init(vm: HomeViewModel) {
+        self._vm = StateObject(wrappedValue: vm)
+    }
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    HomeView(vm: HomeViewModel(coordinator: AppCoordinator()))
+}
+
+
+//// MARK: - Home View
+//struct HomeView: View {
+//    @EnvironmentObject var coordinator: AppCoordinator
+//    @Environment(\.managedObjectContext) private var context
+//    
+//    @FetchRequest(
+//        sortDescriptors: [NSSortDescriptor(keyPath: \Project.updatedDate, ascending: false)],
+//        animation: .default)
+//    private var allProjects: FetchedResults<Project>
+//    
+//    // 현재 선택된 카테고리의 프로젝트들
+//    private var filteredProjects: [Project] {
+//        allProjects.filter { $0.categoryEnum == coordinator.currentCategory }
+//    }
+//    
+//    var body: some View {
+//        VStack {
+//            // 카테고리 선택
+//            categorySelector
+//            
+//            // 메인 컨텐츠
+//            if filteredProjects.isEmpty {
+//                emptyStateView
+//            } else {
+//                projectGridView
+//            }
+//            
+//            Spacer()
+//        }
+//        .navigationTitle(coordinator.currentCategory.displayName)
+//        .navigationBarTitleDisplayMode(.large)
+//        .toolbar {
+//            ToolbarItem(placement: .navigationBarTrailing) {
+//                if coordinator.homeEditMode == .normal {
+//                    Menu {
+//                        Button("새 프로젝트", systemImage: "plus") {
+//                            coordinator.startNewProject()
+//                        }
+//                        Button("편집", systemImage: "pencil") {
+//                            coordinator.startDeleteMode()
+//                        }
+//                        Button("이동", systemImage: "arrow.right") {
+//                            coordinator.startMoveMode()
+//                        }
+//                    } label: {
+//                        Image(systemName: "ellipsis.circle")
+//                    }
+//                } else {
+//                    HStack {
+//                        Button("취소") {
+//                            coordinator.cancelEditMode()
+//                        }
+//                        
+//                        if case .delete(let selected) = coordinator.homeEditMode, !selected.isEmpty {
+//                            Button("삭제") {
+//                                coordinator.deleteSelectedProjects()
+//                            }
+//                            .foregroundColor(.red)
+//                        }
+//                        
+//                        if case .move(let selected) = coordinator.homeEditMode, !selected.isEmpty {
+//                            Button("이동") {
+//                                coordinator.moveSelectedProjects()
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+//    
+//    private var categorySelector: some View {
+//        ScrollView(.horizontal, showsIndicators: false) {
+//            HStack(spacing: 15) {
+//                ForEach(Category.allCases, id: \.self) { category in
+//                    Button {
+//                        coordinator.changeCategory(to: category)
+//                    } label: {
+//                        VStack {
+//                            Image(systemName: category.icon)
+//                                .font(.title2)
+//                            Text(category.displayName)
+//                                .font(.caption)
+//                        }
+//                        .foregroundColor(coordinator.currentCategory == category ? .white : .primary)
+//                        .padding(.horizontal, 16)
+//                        .padding(.vertical, 12)
+//                        .background(
+//                            RoundedRectangle(cornerRadius: 12)
+//                                .fill(coordinator.currentCategory == category ? Color.blue : Color.gray.opacity(0.2))
+//                        )
+//                    }
+//                    .buttonStyle(.plain)
+//                }
+//            }
+//            .padding(.horizontal)
+//        }
+//    }
+//    
+//    private var emptyStateView: some View {
+//        VStack(spacing: 20) {
+//            Image(systemName: coordinator.currentCategory.icon)
+//                .font(.system(size: 60))
+//                .foregroundColor(.gray)
+//            
+//            Text("아직 \(coordinator.currentCategory.displayName) 프로젝트가 없습니다")
+//                .font(.title3)
+//                .multilineTextAlignment(.center)
+//            
+//            Text("새로운 식물을 추가해보세요!")
+//                .foregroundColor(.secondary)
+//            
+//            Button {
+//                coordinator.startNewProject()
+//            } label: {
+//                Label("첫 프로젝트 시작하기", systemImage: "plus")
+//            }
+//            .buttonStyle(.borderedProminent)
+//        }
+//        .padding()
+//    }
+//    
+//    private var projectGridView: some View {
+//        ScrollView {
+//            LazyVGrid(columns: [
+//                GridItem(.flexible()),
+//                GridItem(.flexible())
+//            ], spacing: 15) {
+//                ForEach(filteredProjects, id: \.id) { project in
+//                    ProjectCardView(project: project)
+//                }
+//            }
+//            .padding(.horizontal)
+//        }
+//    }
+//}

--- a/Caladium/Caladium/Views/Screen/HomeView.swift
+++ b/Caladium/Caladium/Views/Screen/HomeView.swift
@@ -10,153 +10,265 @@ import SwiftUI
 struct HomeView: View {
     @StateObject private var vm: HomeViewModel
     
+    @FetchRequest var projects: FetchedResults<Project>
+    
     init(vm: HomeViewModel) {
         self._vm = StateObject(wrappedValue: vm)
+        self._projects = FetchRequest(
+            entity: Project.entity(),
+            sortDescriptors: [NSSortDescriptor(keyPath: \Project.createdDate, ascending: false)],
+            predicate: NSPredicate(format: "category == %@", vm.currentCategory.rawValue)
+        )
     }
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: 0) {
+            // Header with category navigation
+            categoryHeader
+            
+            projectsGrid
+            
+            Spacer()
+            
+            bottomToolbar
+        }
+    }
+    
+    // MARK: - Category Header
+    private var categoryHeader: some View {
+        HStack {
+            Button(action: vm.previousCategory) {
+                Image(systemName: "chevron.left")
+                    .font(.title2)
+                    .foregroundColor(.green)
+                    .padding()
+            }
+            
+            Spacer()
+            
+            VStack {
+                // Category dots indicator
+                HStack(spacing: 8) {
+                    ForEach(Category.allCases, id: \.self) { category in
+                        Circle()
+                            .fill(category == vm.currentCategory ? Color.green : Color.gray.opacity(0.3))
+                            .frame(
+                                width: category == vm.currentCategory ? 10 : 8,
+                                height: category == vm.currentCategory ? 10 : 8)
+                    }
+                }
+                
+                
+                Text(vm.currentCategory.displayName)
+                    .font(.headline)
+                    .padding(.top, 4)
+            }
+            
+            Spacer()
+            
+            Button(action: vm.nextCategory) {
+                Image(systemName: "chevron.right")
+                    .font(.title2)
+                    .foregroundColor(.green)
+                    .padding()
+            }
+        }
+        .padding(.horizontal)
+        .padding(.top)
+    }
+    
+    
+    // MARK: - Projects Grid
+    private var projectsGrid: some View {
+        ScrollView {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 24), count: 3), spacing: 12) {
+                // Add new project button (always first)
+                newProjectButton
+                
+                // Existing projects
+                ForEach(projects, id: \.id) { project in
+                    projectGridItem(project)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 20)
+        }
+    }
+    
+    // MARK: - New Project Button
+    private var newProjectButton: some View {
+        Button(action: vm.startNewProject) {
+            Image(systemName: "plus")
+                .font(.system(size: 30))
+                .foregroundColor(.white)
+                .frame(width: 100, height: 100)
+                .background {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.green)
+                }
+        }
+        .disabled(vm.isEditMode)
+    }
+    
+    // MARK: - Project Grid Item
+    private func projectGridItem(_ project: Project) -> some View {
+        Button(action: {
+            if vm.isEditMode {
+                vm.toggleProjectSelection(project)
+            } else {
+                // Navigate to selected Project
+                vm.selectProject(selectedProject: project)
+            }
+        }) {
+            ZStack {
+                // Project thumbnail (placeholder)
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 100, height: 100)
+                    .overlay(
+                        Image(systemName: "leaf.fill")
+                            .font(.title)
+                            .foregroundColor(.green)
+                    )
+                
+                // Selection indicator
+                if vm.isProjectSelected(project) {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.blue, lineWidth: 3)
+                        .background(Color.blue.opacity(0.2))
+                        .cornerRadius(12)
+                }
+                
+                // Selection checkbox
+                if vm.isEditMode {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            Image(systemName: vm.isProjectSelected(project) ? "checkmark.circle.fill" : "circle")
+                                .foregroundColor(vm.isProjectSelected(project) ? .blue : .white)
+                                .background(Color.black.opacity(0.5))
+                                .clipShape(Circle())
+                        }
+                        Spacer()
+                    }
+                    .padding(8)
+                }
+            }
+        }
+        .buttonStyle(PlainButtonStyle())
+    }
+    
+    // MARK: - Bottom Toolbar
+    private var bottomToolbar: some View {
+        HStack {
+            
+            switch vm.editMode {
+            case .normal:
+                Button {
+                    vm.startDeleteMode()
+                } label: {
+                    VStack {
+                        Image(systemName: "trash")
+                            .font(.title2)
+                        Text("지우기")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.red)
+                }
+                .disabled(projects.isEmpty)
+                
+                Spacer()
+                
+                Button {
+                    vm.startMoveMode()
+                } label: {
+                    VStack {
+                        Image(systemName: "folder")
+                            .font(.title2)
+                        Text("옮기기")
+                            .font(.caption)
+                    }
+                }
+                .disabled(projects.isEmpty)
+
+            case .delete(_):
+                Button {
+                    vm.exitEditMode()
+                } label: {
+                    VStack{
+                        Image(systemName: "xmark")
+                            .font(.title2)
+                        Text("취소")
+                            .font(.caption)
+                    }
+                }
+                
+                Spacer()
+                
+                if vm.selectedProjectsCount > 0 {
+                    Text("\(vm.selectedProjectsCount)개 선택됨")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button {
+                   // TODO: 선택한 프로젝트들 삭제 로직 호출
+                } label: {
+                    VStack{
+                        Image(systemName: "checkmark")
+                            .font(.title2)
+                        Text("확인")
+                            .font(.caption)
+                    }
+                }
+
+            case .move(_):
+                Button {
+                    vm.exitEditMode()
+                } label: {
+                    VStack{
+                        Image(systemName: "xmark")
+                            .font(.title2)
+                        Text("취소")
+                            .font(.caption)
+                    }
+                }
+                
+                Spacer()
+                
+                if vm.selectedProjectsCount > 0 {
+                    Text("\(vm.selectedProjectsCount)개 선택됨")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button {
+                    // TODO: 선택한 프로젝트들 옮기기 로직 호출
+                } label: {
+                    VStack{
+                        Image(systemName: "checkmark")
+                            .font(.title2)
+                        Text("확인")
+                            .font(.caption)
+                    }
+                }
+            }
+            
+        }
+        .padding(.horizontal, 40)
+        .padding(.vertical, 16)
+        .background(Color(.systemBackground))
+        .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: -1)
+        
     }
 }
 
 #Preview {
     HomeView(vm: HomeViewModel(coordinator: AppCoordinator()))
+        .environment(\.managedObjectContext, CoreDataManager.preview.mainContext)
 }
 
-
-//// MARK: - Home View
-//struct HomeView: View {
-//    @EnvironmentObject var coordinator: AppCoordinator
-//    @Environment(\.managedObjectContext) private var context
-//    
-//    @FetchRequest(
-//        sortDescriptors: [NSSortDescriptor(keyPath: \Project.updatedDate, ascending: false)],
-//        animation: .default)
-//    private var allProjects: FetchedResults<Project>
-//    
-//    // 현재 선택된 카테고리의 프로젝트들
-//    private var filteredProjects: [Project] {
-//        allProjects.filter { $0.categoryEnum == coordinator.currentCategory }
-//    }
-//    
-//    var body: some View {
-//        VStack {
-//            // 카테고리 선택
-//            categorySelector
-//            
-//            // 메인 컨텐츠
-//            if filteredProjects.isEmpty {
-//                emptyStateView
-//            } else {
-//                projectGridView
-//            }
-//            
-//            Spacer()
-//        }
-//        .navigationTitle(coordinator.currentCategory.displayName)
-//        .navigationBarTitleDisplayMode(.large)
-//        .toolbar {
-//            ToolbarItem(placement: .navigationBarTrailing) {
-//                if coordinator.homeEditMode == .normal {
-//                    Menu {
-//                        Button("새 프로젝트", systemImage: "plus") {
-//                            coordinator.startNewProject()
-//                        }
-//                        Button("편집", systemImage: "pencil") {
-//                            coordinator.startDeleteMode()
-//                        }
-//                        Button("이동", systemImage: "arrow.right") {
-//                            coordinator.startMoveMode()
-//                        }
-//                    } label: {
-//                        Image(systemName: "ellipsis.circle")
-//                    }
-//                } else {
-//                    HStack {
-//                        Button("취소") {
-//                            coordinator.cancelEditMode()
-//                        }
-//                        
-//                        if case .delete(let selected) = coordinator.homeEditMode, !selected.isEmpty {
-//                            Button("삭제") {
-//                                coordinator.deleteSelectedProjects()
-//                            }
-//                            .foregroundColor(.red)
-//                        }
-//                        
-//                        if case .move(let selected) = coordinator.homeEditMode, !selected.isEmpty {
-//                            Button("이동") {
-//                                coordinator.moveSelectedProjects()
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//    
-//    private var categorySelector: some View {
-//        ScrollView(.horizontal, showsIndicators: false) {
-//            HStack(spacing: 15) {
-//                ForEach(Category.allCases, id: \.self) { category in
-//                    Button {
-//                        coordinator.changeCategory(to: category)
-//                    } label: {
-//                        VStack {
-//                            Image(systemName: category.icon)
-//                                .font(.title2)
-//                            Text(category.displayName)
-//                                .font(.caption)
-//                        }
-//                        .foregroundColor(coordinator.currentCategory == category ? .white : .primary)
-//                        .padding(.horizontal, 16)
-//                        .padding(.vertical, 12)
-//                        .background(
-//                            RoundedRectangle(cornerRadius: 12)
-//                                .fill(coordinator.currentCategory == category ? Color.blue : Color.gray.opacity(0.2))
-//                        )
-//                    }
-//                    .buttonStyle(.plain)
-//                }
-//            }
-//            .padding(.horizontal)
-//        }
-//    }
-//    
-//    private var emptyStateView: some View {
-//        VStack(spacing: 20) {
-//            Image(systemName: coordinator.currentCategory.icon)
-//                .font(.system(size: 60))
-//                .foregroundColor(.gray)
-//            
-//            Text("아직 \(coordinator.currentCategory.displayName) 프로젝트가 없습니다")
-//                .font(.title3)
-//                .multilineTextAlignment(.center)
-//            
-//            Text("새로운 식물을 추가해보세요!")
-//                .foregroundColor(.secondary)
-//            
-//            Button {
-//                coordinator.startNewProject()
-//            } label: {
-//                Label("첫 프로젝트 시작하기", systemImage: "plus")
-//            }
-//            .buttonStyle(.borderedProminent)
-//        }
-//        .padding()
-//    }
-//    
-//    private var projectGridView: some View {
-//        ScrollView {
-//            LazyVGrid(columns: [
-//                GridItem(.flexible()),
-//                GridItem(.flexible())
-//            ], spacing: 15) {
-//                ForEach(filteredProjects, id: \.id) { project in
-//                    ProjectCardView(project: project)
-//                }
-//            }
-//            .padding(.horizontal)
-//        }
-//    }
-//}

--- a/Caladium/Caladium/Views/Screen/HomeView.swift
+++ b/Caladium/Caladium/Views/Screen/HomeView.swift
@@ -30,8 +30,18 @@ struct HomeView: View {
             
             Spacer()
             
+            Button {
+                vm.addMockData()
+            } label: {
+                Text("Mock Data Add")
+
+            }
+            .padding()
+
+            
             bottomToolbar
         }
+        .navigationTitle("") // 빈 문자열로 설정
     }
     
     // MARK: - Category Header

--- a/Caladium/Caladium/Views/Screen/OnboardingView.swift
+++ b/Caladium/Caladium/Views/Screen/OnboardingView.swift
@@ -9,8 +9,13 @@ import SwiftUI
 
 // MARK: - Onboarding Views
 struct OnboardingContainerView: View {
-    @EnvironmentObject var coordinator: AppCoordinator
+    private var coordinator: AppCoordinator
     @State private var currentStep: OnboardingStep = .welcome
+    
+    init(coordinator: AppCoordinator) {
+        self.coordinator = coordinator
+        
+    }
     
     var body: some View {
         VStack(spacing: 20) {

--- a/Caladium/Caladium/Views/Screen/OnboardingView.swift
+++ b/Caladium/Caladium/Views/Screen/OnboardingView.swift
@@ -1,0 +1,95 @@
+//
+//  OnboardingView.swift
+//  Caladium
+//
+//  Created by 이종선 on 6/22/25.
+//
+
+import SwiftUI
+
+// MARK: - Onboarding Views
+struct OnboardingContainerView: View {
+    @EnvironmentObject var coordinator: AppCoordinator
+    @State private var currentStep: OnboardingStep = .welcome
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("온보딩 - \(currentStep.rawValue + 1)/\(OnboardingStep.allCases.count)")
+                .font(.title2)
+                .bold()
+            
+            switch currentStep {
+            case .welcome:
+                VStack(spacing: 15) {
+                    Text("🌱 Caladium에 오신 것을 환영합니다!")
+                        .font(.title)
+                    Text("식물의 성장을 기록하고 타임랩스 영상을 만들어보세요")
+                        .foregroundColor(.secondary)
+                }
+                
+            case .features:
+                VStack(spacing: 15) {
+                    Text("✨ 주요 기능")
+                        .font(.title)
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("📸 정기적인 사진 촬영")
+                        Text("🎬 타임랩스 영상 제작")
+                        Text("🗂 카테고리별 정리")
+                        Text("📈 성장 과정 추적")
+                    }
+                }
+                
+            case .permissions:
+                VStack(spacing: 15) {
+                    Text("📷 권한 설정")
+                        .font(.title)
+                    Text("카메라 권한이 필요합니다")
+                        .foregroundColor(.secondary)
+                    Button("권한 허용하기") {
+                        // 실제로는 권한 요청 로직
+                        currentStep = .complete
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+                
+            case .complete:
+                VStack(spacing: 15) {
+                    Text("🎉 설정 완료!")
+                        .font(.title)
+                    Text("이제 첫 번째 식물을 추가해보세요")
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            Spacer()
+            
+            HStack {
+                if currentStep != .welcome {
+                    Button("이전") {
+                        if let previous = currentStep.previous {
+                            currentStep = previous
+                        }
+                    }
+                }
+                
+                Spacer()
+                
+                if currentStep == .complete {
+                    Button("시작하기") {
+                        coordinator.completeOnboarding()
+                    }
+                    .buttonStyle(.borderedProminent)
+                } else {
+                    Button("다음") {
+                        if let next = currentStep.next {
+                            currentStep = next
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding()
+    }
+}
+

--- a/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
@@ -1,0 +1,142 @@
+//
+//  ProjectDetailView.swift
+//  Caladium
+//
+//  Created by 이종선 on 6/22/25.
+//
+
+import SwiftUI
+import CoreData
+
+// MARK: - Project Detail View
+struct ProjectDetailView: View {
+    
+    @StateObject private var vm: ProjectDetailViewModel
+
+    let project: Project
+    @FetchRequest private var photos: FetchedResults<Photo>
+    
+    init(vm: ProjectDetailViewModel, project: Project) {
+        self._vm = StateObject(wrappedValue: vm)
+        self.project = project
+        self._photos = FetchRequest(
+            entity: Photo.entity(),
+            sortDescriptors: [NSSortDescriptor(keyPath: \Photo.capturedDate, ascending: true)],
+            predicate: NSPredicate(format: "project == %@", project)
+        )
+    }
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // 프로젝트 정보
+                VStack(spacing: 10) {
+                    Text("📊 프로젝트 정보")
+                        .font(.title2)
+                        .bold()
+                    
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("카테고리: \(project.categoryEnum.displayName)")
+                        Text("생성일: \(project.createdDate?.formatted() ?? "")")
+                        Text("마지막 업데이트: \(project.updatedDate?.formatted() ?? "")")
+                        Text("사진 수: \(photos.count)장")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+                
+                // 액션 버튼들
+                VStack(spacing: 12) {
+                    Button {
+//                        coordinator.addPhotoToProject(project)
+                    } label: {
+                        Label("사진 추가", systemImage: "camera")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    
+                    if photos.count >= 2 {
+                        Button {
+                        } label: {
+                            Label("영상 만들기", systemImage: "video")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                }
+                
+                // 사진 그리드
+                if !photos.isEmpty {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("📷 사진들")
+                            .font(.title2)
+                            .bold()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        
+                        LazyVGrid(columns: [
+                            GridItem(.flexible()),
+                            GridItem(.flexible()),
+                            GridItem(.flexible())
+                        ], spacing: 10) {
+                            ForEach(photos, id: \.id) { photo in
+                                Button {
+                                } label: {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .fill(Color.gray.opacity(0.3))
+                                        .aspectRatio(1, contentMode: .fit)
+                                        .overlay {
+                                            VStack {
+                                                Image(systemName: "photo")
+                                                Text(photo.capturedDate?.formatted(date: .abbreviated, time: .omitted) ?? "")
+                                                    .font(.caption2)
+                                            }
+                                            .foregroundColor(.gray)
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("프로젝트 상세")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+
+
+
+
+// Preview 밖에서 helper 함수 정의
+private func getSampleProject(from context: NSManagedObjectContext) -> Project {
+    let fetchRequest: NSFetchRequest<Project> = Project.fetchRequest()
+    fetchRequest.fetchLimit = 1
+    
+    if let existingProject = try? context.fetch(fetchRequest).first {
+        return existingProject
+    }
+    
+    // 없으면 새로 생성
+    let project = Project(context: context)
+    project.id = UUID()
+    project.createdDate = Date()
+    project.updatedDate = Date()
+    project.category = Category.rooftop.rawValue
+    return project
+}
+
+#Preview {
+    let context = CoreDataManager.preview.mainContext
+    let sampleProject = getSampleProject(from: context)
+    
+    return ProjectDetailView(
+        vm: ProjectDetailViewModel(coordinator: AppCoordinator()),
+        project: sampleProject
+    )
+    .environment(\.managedObjectContext, context)
+}

--- a/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
@@ -12,7 +12,7 @@ import CoreData
 struct ProjectDetailView: View {
     
     @StateObject private var vm: ProjectDetailViewModel
-
+    
     let project: Project
     @FetchRequest private var photos: FetchedResults<Photo>
     
@@ -27,89 +27,257 @@ struct ProjectDetailView: View {
     }
     
     var body: some View {
+        VStack(spacing: 0) {
+            photoGrid
+                .overlay(alignment: .bottomTrailing){
+                    cameraButton
+                        .padding()
+                }
+            
+            bottomToolbar
+        }
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(dateRangeText)
+                    .font(.subheadline) // 또는 .caption, .footnote
+                    .foregroundColor(.primary)
+            }
+        }
+        
+    }
+    
+    // MARK: - Photo Grid
+
+    private var photoGrid: some View {
         ScrollView {
-            VStack(spacing: 20) {
-                // 프로젝트 정보
-                VStack(spacing: 10) {
-                    Text("📊 프로젝트 정보")
-                        .font(.title2)
-                        .bold()
-                    
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("카테고리: \(project.categoryEnum.displayName)")
-                        Text("생성일: \(project.createdDate?.formatted() ?? "")")
-                        Text("마지막 업데이트: \(project.updatedDate?.formatted() ?? "")")
-                        Text("사진 수: \(photos.count)장")
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
-                    .background(Color.gray.opacity(0.1))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 3), count: 3), spacing: 3) {
+                ForEach(photos, id: \.objectID) { photo in
+                    photoGridItem(photo: photo)
                 }
-                
-                // 액션 버튼들
-                VStack(spacing: 12) {
-                    Button {
-//                        coordinator.addPhotoToProject(project)
-                    } label: {
-                        Label("사진 추가", systemImage: "camera")
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    
-                    if photos.count >= 2 {
-                        Button {
-                        } label: {
-                            Label("영상 만들기", systemImage: "video")
-                                .frame(maxWidth: .infinity)
+            }
+            .padding(.horizontal, 1)
+
+        }
+    }
+    
+    private func photoGridItem(photo: Photo) -> some View {
+            ZStack {
+                AsyncPhotoImage(photo: photo)
+                    .frame(width:128, height: 128)
+                    .clipped()
+                    .onTapGesture {
+                        if vm.isEditMode {
+                            vm.togglePhotoSelection(photo)
+                        } else {
+                            // TODO: 사진 상세보기로 이동
+                            vm.navigateToPhotoDetail(photo: photo, project: project)
                         }
-                        .buttonStyle(.bordered)
                     }
-                }
                 
-                // 사진 그리드
-                if !photos.isEmpty {
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("📷 사진들")
-                            .font(.title2)
-                            .bold()
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        
-                        LazyVGrid(columns: [
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible())
-                        ], spacing: 10) {
-                            ForEach(photos, id: \.id) { photo in
-                                Button {
-                                } label: {
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color.gray.opacity(0.3))
-                                        .aspectRatio(1, contentMode: .fit)
-                                        .overlay {
-                                            VStack {
-                                                Image(systemName: "photo")
-                                                Text(photo.capturedDate?.formatted(date: .abbreviated, time: .omitted) ?? "")
-                                                    .font(.caption2)
-                                            }
-                                            .foregroundColor(.gray)
-                                        }
-                                }
-                                .buttonStyle(.plain)
-                            }
+                // 선택 표시
+                if vm.isEditMode {
+                    VStack {
+                        HStack {
+                            Spacer()
+                            Circle()
+                                .fill(vm.isPhotoSelected(photo) ? Color.blue : Color.clear)
+                                .stroke(Color.white, lineWidth: 2)
+                                .frame(width: 24, height: 24)
+                                .overlay(
+                                    Image(systemName: "checkmark")
+                                        .font(.system(size: 12, weight: .bold))
+                                        .foregroundColor(.white)
+                                        .opacity(vm.isPhotoSelected(photo) ? 1 : 0)
+                                )
+                                .padding(8)
                         }
+                        Spacer()
                     }
                 }
             }
-            .padding()
         }
-        .navigationTitle("프로젝트 상세")
-        .navigationBarTitleDisplayMode(.inline)
+    
+    private var cameraButton: some View {
+        HStack(alignment: .center,spacing: 18){
+            Image(systemName: "camera.fill")
+                .font(.system(size: 30, weight: .medium))
+                .foregroundColor(.white)
+                .background{
+                   Rectangle()
+                        .fill(Color.green500)
+                        .frame(width: 60, height: 60)
+                        
+                }
+                .padding(.leading, 8)
+            
+            VStack(spacing: 4){
+                Text("새로운 사진")
+                    .font(.caption)
+                    .foregroundStyle(.primary)
+                Text("촬영하기")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.leading,10)
+        
+
+        }
+        .onTapGesture {
+            vm.addNewPhoto(currentProject: project)
+        }
+        .frame(width: 158, height: 58, alignment: .leading)
+        .background{
+            Rectangle()
+                .fill(Color.white)
+               
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.gray400, lineWidth: 2)
+        )
+
+        
+    }
+    
+    
+    private var bottomToolbar: some View {
+        HStack {
+            
+            switch vm.editMode {
+            case .normal:
+                Button {
+                    vm.startDeleteMode()
+                } label: {
+                    VStack {
+                        Image(systemName: "trash")
+                            .font(.title2)
+                        Text("지우기")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.red)
+                }
+                .disabled(photos.isEmpty)
+                
+                Spacer()
+                
+                Button {
+                    vm.startVideoMode()
+                } label: {
+                    VStack {
+                        Image(systemName: "folder")
+                            .font(.title2)
+                        Text("옮기기")
+                            .font(.caption)
+                    }
+                }
+                .disabled(photos.isEmpty)
+
+            case .delete(_):
+                Button {
+                    vm.exitEditMode()
+                } label: {
+                    VStack{
+                        Image(systemName: "xmark")
+                            .font(.title2)
+                        Text("취소")
+                            .font(.caption)
+                    }
+                }
+                
+                Spacer()
+                
+                if vm.selectedProjectsCount > 0 {
+                    Text("\(vm.selectedProjectsCount)개 선택됨")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button {
+                   // TODO: 선택한 프로젝트들 삭제 로직 호출
+                } label: {
+                    VStack{
+                        Image(systemName: "checkmark")
+                            .font(.title2)
+                        Text("확인")
+                            .font(.caption)
+                    }
+                }
+
+            case .makeVideo(_):
+                Button {
+                    vm.exitEditMode()
+                } label: {
+                    VStack{
+                        Image(systemName: "xmark")
+                            .font(.title2)
+                        Text("취소")
+                            .font(.caption)
+                    }
+                }
+                
+                Spacer()
+                
+                if vm.selectedProjectsCount > 0 {
+                    Text("\(vm.selectedProjectsCount)개 선택됨")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                Button {
+                    // TODO: 비디오 만들기 로직 호출
+                } label: {
+                    VStack{
+                        Image(systemName: "checkmark")
+                            .font(.title2)
+                        Text("확인")
+                            .font(.caption)
+                    }
+                }
+            }
+            
+        }
+        .padding(.horizontal, 40)
+        .padding(.vertical, 16)
+        .background(Color(.systemBackground))
+        .shadow(color: .black.opacity(0.1), radius: 1, x: 0, y: -1)
+        
+    }
+    
+    
+    private var dateRangeText: String {
+        let formatter = Date.FormatStyle()
+            .year()
+            .month(.wide)
+            .day()
+            .locale(Locale(identifier: "ko_KR"))
+        
+        let startDate = project.createdDate?.formatted(formatter) ?? ""
+        let endDate = project.updatedDate?.formatted(formatter) ?? ""
+        
+        return "\(startDate) ~ \(endDate)"
     }
 }
 
 
 
+
+#Preview {
+    let context = CoreDataManager.preview.mainContext
+    let sampleProject = getSampleProject(from: context)
+    
+    return ProjectDetailView(
+        vm: ProjectDetailViewModel(coordinator: AppCoordinator()),
+        project: sampleProject
+    )
+    .environment(\.managedObjectContext, context)
+}
 
 
 // Preview 밖에서 helper 함수 정의
@@ -128,15 +296,4 @@ private func getSampleProject(from context: NSManagedObjectContext) -> Project {
     project.updatedDate = Date()
     project.category = Category.rooftop.rawValue
     return project
-}
-
-#Preview {
-    let context = CoreDataManager.preview.mainContext
-    let sampleProject = getSampleProject(from: context)
-    
-    return ProjectDetailView(
-        vm: ProjectDetailViewModel(coordinator: AppCoordinator()),
-        project: sampleProject
-    )
-    .environment(\.managedObjectContext, context)
 }


### PR DESCRIPTION
# 설명
이 PR은 다음과 같은 변경 사항을 포함합니다:
- HomeView, ProjectDetailView를 기본 화면 구성 및 기본 상호작용 컴포넌트 구현
- 각 View에 대한 ViewModel 구현 및 AppCoordinator 연결
- AppRoute 에 ProjectDetailView 플로우에 대한 화면 case 추가 
- 프리뷰를 위한 memory container 따로 추가 
- mockData 생성 방식 변경 

## 추후 고려할 내용 
- 현재 각 뷰와 뷰 모델을 구현하는 과정에서 각각에 필요한 의존성을 임의로 주입하여 이후 의존성에 대한 정리가 필요합니다. (현재 AsyncPhotoImage 의 경우에는 환경 컨테이너를 통해 coreDataService에 접근하고 있음)
- 현재 CoreDataService를 통해 사진을 로딩하고 있는데, 사진 로딩에 대한 별도 분리를 고려해볼 수도 있습니다. 
- 각 화면에서 디자인이 반영된 컴포넌트 교체가 필요합니다. 
- 현재 메인 홈뷰에 mock 데이터 생성을 위한 버튼이 있습니다.( 이후 삭제 필요) 
