### PR TITLE
영상만들기 팝업 이탈 로직 추가

### DIFF
--- a/Caladium/Caladium.xcodeproj/project.pbxproj
+++ b/Caladium/Caladium.xcodeproj/project.pbxproj
@@ -283,7 +283,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onemorethink.Caladium;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -319,7 +319,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.onemorethink.Caladium;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";

--- a/Caladium/Caladium/Views/Componenets/LoadingView.swift
+++ b/Caladium/Caladium/Views/Componenets/LoadingView.swift
@@ -6,13 +6,14 @@
 //
 
 import SwiftUI
+import RiveRuntime
 
 struct LoadingView: View {
     var body: some View {
         ZStack {
-            Color.green300
+            Color.gray0
                 .ignoresSafeArea()
-            
+            RiveViewModel(fileName: "loading_jegeo").view()
         }
     }
 }

--- a/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/ProjectDetailView.swift
@@ -64,6 +64,13 @@ struct ProjectDetailView: View {
                 } background: {
                     Rectangle()
                         .fill(.primary.opacity(0.35))
+                        .ignoresSafeArea()
+                        .onTapGesture {
+                            let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
+                            impactFeedback.impactOccurred()
+                            
+                            vm.isShowingFormatSelectAlert = false
+                        }
                 }
             
             BottomToolbar(


### PR DESCRIPTION
📌 설명
- 영상 만들기 팝업에서 취소 버튼 또는 뒤로가기 동작이 제공되지 않아, 사용자가 화면을 이탈할 수 없는 문제가 있었음
- 다른 화면으로 빠져나갈 수 있는 선택지가 UI 상에 존재하지 않았음
- 팝업 외부 영역(백그라운드)을 탭하면 팝업이 닫히도록 로직을 추가함