### PR TITLE
[feat] 사진 상세 화면 기능 추가

### DIFF
--- a/Caladium/Caladium/App/ContentView.swift
+++ b/Caladium/Caladium/App/ContentView.swift
@@ -50,8 +50,8 @@ struct ContentView: View {
         case .projectDetail(let project):
             ProjectDetailView(vm: dependencies.makeProjectDetailViewModel(), project: project)
             
-        case .photoDetail(let photo, _):
-            PhotoDetailView(photo: photo)
+        case .photoDetail(let photo, let project):
+            PhotoDetailView(photo: photo, project: project)
             
         case .camera(let context, let latestPhoto):
             CameraView(vm: dependencies.makeCameraViewModel(context: context, latestPhoto: latestPhoto))

--- a/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
@@ -6,11 +6,24 @@
 //
 
 import SwiftUI
+import CoreData
 
 struct PhotoDetailView: View {
-    let photo: Photo
+    let project: Project
     
     @Environment(\.dismiss) private var dismiss
+    @State private var currentPhoto: Photo
+    @FetchRequest private var photos: FetchedResults<Photo>
+    
+    init(photo: Photo, project: Project) {
+        self.project = project
+        self._currentPhoto = State(initialValue: photo)
+        self._photos = FetchRequest(
+            entity: Photo.entity(),
+            sortDescriptors: [NSSortDescriptor(keyPath: \Photo.capturedDate, ascending: true)],
+            predicate: NSPredicate(format: "project == %@", project)
+        )
+    }
 
     var body: some View {
         ZStack(alignment: .leading) {
@@ -20,10 +33,8 @@ struct PhotoDetailView: View {
                 .ignoresSafeArea()
             
             VStack(spacing: 0){
-                // 상단 툴바 영역
                 HStack {
                     Button {
-                        // 햅틱 피드백 추가
                         let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
                         impactFeedback.impactOccurred()
                         
@@ -38,17 +49,78 @@ struct PhotoDetailView: View {
                 .frame(height: 68)
                 .padding(.top, 54)
                 
-                PhotoFrame(photo: photo)
+                PhotoFrame(photo: currentPhoto)
+                    .id(currentPhoto.objectID)
                     .padding(.top, 20)
                     .padding(.horizontal, 18)
+                    .padding(.bottom, 51)
                 
-                Spacer()
+                thumbnailScrollView
+                    .padding(.bottom, 32)
             }
             .ignoresSafeArea(.all)
             .navigationBarHidden(true)
         }
+    }
+    
+    // MARK: - Thumbnail Scroll View
+    private var thumbnailScrollView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 3) {
+                ForEach(photos, id: \.objectID) { photo in
+                    thumbnailItem(photo: photo)
+                }
+            }
+            .padding(.vertical, 14)
+        }
+        .background(
+            Rectangle()
+                .fill(Color.gray0)
+                .shadow(color: .gray900.opacity(0.25), radius: 1.5, x: 0, y: 2)
+                .border(Color.gray400, width: 1)
+        )
+        
         
     }
+    
+    // MARK: - Thumbnail Item
+    private func thumbnailItem(photo: Photo) -> some View {
+        Button {
+            currentPhoto = photo
+            
+        } label: {
+            if case .normal = thumbnailState(for: photo) {
+                AsyncPhotoImage(photo: photo)
+                    .clipShape(Rectangle())
+                    .frame(width: 57, height: 77)
+                
+            } else if case .selected = thumbnailState(for: photo) {
+                ZStack {
+                    AsyncPhotoImage(photo: photo)
+                        .clipShape(Rectangle())
+                        .frame(width: 57, height: 77)
+                    Rectangle()
+                        .foregroundColor(.gray900.opacity(0.5))
+                        .frame(width: 57, height: 77)
+                    Text("now")
+                        .customFont(.categoryButtonTitle)
+                        .foregroundColor(.gray0)
+                    
+                }
+            }
+        }
+    }
+    
+    // MARK: - Thumbnail State
+    private func thumbnailState(for photo: Photo) -> PhotoThumbnailState {
+        // 현재 선택된 사진은 selected 상태로 표시
+        return photo.objectID == currentPhoto.objectID ? .selected : .normal
+    }
+    
+    // MARK: - Current Photo Index
+//    private var currentPhotoIndex: Int {
+//        photos.firstIndex { $0.objectID == currentPhoto.objectID } ?? 0
+//    }
 }
 
 #Preview {
@@ -62,13 +134,28 @@ struct PhotoDetailView: View {
     mockProject.createdDate = Date()
     mockProject.updatedDate = Date()
     
-    // Mock 사진 생성
-    let mockPhoto = Photo(context: previewContext,
-                         fileName: "sample.jpg",
-                         project: mockProject)
+    var mockPhotos: [Photo] = []
+        for i in 1...5 {
+            // Mock 사진 생성
+            let mockPhoto = Photo(context: previewContext,
+                                fileName: "sample\(i).jpg",
+                                project: mockProject)
+            mockPhoto.capturedDate = Date().addingTimeInterval(TimeInterval(i * 3600 * 24)) // 1시간씩 간격
+            mockPhotos.append(mockPhoto)
+        }
     
-    return PhotoDetailView(photo: mockPhoto)
+    // ✅ 컨텍스트에 저장
+    do {
+        try previewContext.save()
+    } catch {
+        print("Preview context save failed: \(error)")
+    }
+    
+    // Mock coordinator (실제 구현에서는 적절한 coordinator 전달)
+    let mockCoordinator = AppCoordinator()
+    
+    // 첫 번째 사진을 초기 사진으로 설정
+    return PhotoDetailView(photo: mockPhotos[0], project: mockProject)
         .previewLayout(.sizeThatFits)
+        .environment(\.managedObjectContext, previewContext) // ✅ 컨텍스트 환경 설정
 }
-
-

--- a/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
@@ -27,7 +27,7 @@ struct PhotoDetailView: View {
             predicate: NSPredicate(format: "project == %@", project)
         )
     }
-
+    
     var body: some View {
         ZStack(alignment: .leading) {
             Image("bg-picture")
@@ -100,18 +100,18 @@ struct PhotoDetailView: View {
     private var thumbnailScrollView: some View {
         ScrollViewReader { proxy in
             GeometryReader { geometry in
-            ScrollView(.horizontal, showsIndicators: false) {
-                LazyHStack(spacing: 3) {
-                    ForEach(photos, id: \.objectID) { photo in
-                        thumbnailItem(photo: photo)
-                            .id(photo.objectID)
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 3) {
+                        ForEach(photos, id: \.objectID) { photo in
+                            thumbnailItem(photo: photo)
+                                .id(photo.objectID)
+                        }
                     }
+                    .padding(.vertical, 14)
+                    .padding(.horizontal, geometry.size.width / 2 - 28.5)
+                    
                 }
-                .padding(.vertical, 14)
-                .padding(.horizontal, geometry.size.width / 2 - 28.5)
-                
             }
-        }
             .frame(height: 105)
             .background(
                 Rectangle()
@@ -120,23 +120,21 @@ struct PhotoDetailView: View {
                     .border(Color.gray400, width: 1)
             )
             .onAppear {
-                // 초기 선택된 사진의 인덱스 찾기
-                    if let index = photos.firstIndex(where: { $0.objectID == currentPhoto.objectID }) {
-                        currentPhotoIndex = index
+                if let index = photos.firstIndex(where: { $0.objectID == currentPhoto.objectID }) {
+                    currentPhotoIndex = index
+                }
+                
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
+                        proxy.scrollTo(currentPhoto.objectID, anchor: .center)
                     }
-                        // 화면이 처음 나타날 때 현재 선택된 썸네일로 스크롤
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
-                                proxy.scrollTo(currentPhoto.objectID, anchor: .center)
-                            }
-                        }
-                    }
+                }
+            }
             .onChange(of: currentPhoto) { newPhoto in
-                        // currentPhoto가 변경될 때마다 해당 썸네일로 스크롤
-                        withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
-                            proxy.scrollTo(newPhoto.objectID, anchor: .center)
-                        }
-                    }
+                withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
+                    proxy.scrollTo(newPhoto.objectID, anchor: .center)
+                }
+            }
         }
         
     }
@@ -149,10 +147,9 @@ struct PhotoDetailView: View {
             
             currentPhoto = photo
             
-            // 클릭된 사진의 인덱스로 currentPhotoIndex 업데이트
-                    if let index = photos.firstIndex(where: { $0.objectID == photo.objectID }) {
-                        currentPhotoIndex = index
-                    }
+            if let index = photos.firstIndex(where: { $0.objectID == photo.objectID }) {
+                currentPhotoIndex = index
+            }
             
         } label: {
             if case .normal = thumbnailState(for: photo) {
@@ -179,49 +176,38 @@ struct PhotoDetailView: View {
     
     // MARK: - Thumbnail State
     private func thumbnailState(for photo: Photo) -> PhotoThumbnailState {
-        // 현재 선택된 사진은 selected 상태로 표시
         return photo.objectID == currentPhoto.objectID ? .selected : .normal
     }
     
-    // MARK: - Current Photo Index
-//    private var currentPhotoIndex: Int {
-//        photos.firstIndex { $0.objectID == currentPhoto.objectID } ?? 0
-//    }
 }
 
 #Preview {
-    // Preview를 위한 임시 컨텍스트 생성
     let previewContext = CoreDataManager.shared.mainContext
     
-    // Mock 프로젝트 생성 (Category enum이 필요하므로 기본값 사용)
     let mockProject = Project(context: previewContext)
     mockProject.id = UUID()
-    mockProject.category = "garden" // Category의 기본값으로 가정
+    mockProject.category = "garden"
     mockProject.createdDate = Date()
     mockProject.updatedDate = Date()
     
     var mockPhotos: [Photo] = []
-        for i in 1...5 {
-            // Mock 사진 생성
-            let mockPhoto = Photo(context: previewContext,
-                                fileName: "sample\(i).jpg",
-                                project: mockProject)
-            mockPhoto.capturedDate = Date().addingTimeInterval(TimeInterval(i * 3600 * 24)) // 1시간씩 간격
-            mockPhotos.append(mockPhoto)
-        }
+    for i in 1...5 {
+        let mockPhoto = Photo(context: previewContext,
+                              fileName: "sample\(i).jpg",
+                              project: mockProject)
+        mockPhoto.capturedDate = Date().addingTimeInterval(TimeInterval(i * 3600 * 24))
+        mockPhotos.append(mockPhoto)
+    }
     
-    // ✅ 컨텍스트에 저장
     do {
         try previewContext.save()
     } catch {
         print("Preview context save failed: \(error)")
     }
     
-    // Mock coordinator (실제 구현에서는 적절한 coordinator 전달)
     let mockCoordinator = AppCoordinator()
     
-    // 첫 번째 사진을 초기 사진으로 설정
     return PhotoDetailView(photo: mockPhotos[0], project: mockProject)
         .previewLayout(.sizeThatFits)
-        .environment(\.managedObjectContext, previewContext) // ✅ 컨텍스트 환경 설정
+        .environment(\.managedObjectContext, previewContext)
 }

--- a/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
@@ -11,6 +11,9 @@ import CoreData
 struct PhotoDetailView: View {
     let project: Project
     
+    @State private var dragOffset: CGFloat = 0
+    @State private var currentPhotoIndex: Int = 0
+    
     @Environment(\.dismiss) private var dismiss
     @State private var currentPhoto: Photo
     @FetchRequest private var photos: FetchedResults<Photo>
@@ -49,11 +52,41 @@ struct PhotoDetailView: View {
                 .frame(height: 68)
                 .padding(.top, 54)
                 
-                PhotoFrame(photo: currentPhoto)
-                    .id(currentPhoto.objectID)
-                    .padding(.top, 20)
-                    .padding(.horizontal, 18)
-                    .padding(.bottom, 51)
+                GeometryReader { geometry in
+                    HStack(spacing: 18) {
+                        ForEach(Array(photos.enumerated()), id: \.element.objectID) { index, photo in
+                            PhotoFrame(photo: photo)
+                                .frame(width: geometry.size.width)
+                                .id(photo.objectID)
+                        }
+                    }
+                    .offset(x: -CGFloat(currentPhotoIndex) * (geometry.size.width + 18) + dragOffset)
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                dragOffset = value.translation.width
+                            }
+                            .onEnded { value in
+                                let threshold: CGFloat = 50
+                                
+                                withAnimation(.spring(response: 0.5, dampingFraction: 0.8)) {
+                                    if value.translation.width > threshold && currentPhotoIndex > 0 {
+                                        // 이전 사진
+                                        currentPhotoIndex -= 1
+                                    } else if value.translation.width < -threshold && currentPhotoIndex < photos.count - 1 {
+                                        // 다음 사진
+                                        currentPhotoIndex += 1
+                                    }
+                                    
+                                    currentPhoto = photos[currentPhotoIndex]
+                                    dragOffset = 0
+                                }
+                            }
+                    )
+                }
+                .padding(.top, 20)
+                .padding(.horizontal, 18)
+                .padding(.bottom, 51)
                 
                 thumbnailScrollView
                     .padding(.bottom, 32)
@@ -76,9 +109,10 @@ struct PhotoDetailView: View {
                 }
                 .padding(.vertical, 14)
                 .padding(.horizontal, geometry.size.width / 2 - 28.5)
-                .frame(height: 105)
+                
             }
         }
+            .frame(height: 105)
             .background(
                 Rectangle()
                     .fill(Color.gray0)
@@ -86,16 +120,20 @@ struct PhotoDetailView: View {
                     .border(Color.gray400, width: 1)
             )
             .onAppear {
+                // 초기 선택된 사진의 인덱스 찾기
+                    if let index = photos.firstIndex(where: { $0.objectID == currentPhoto.objectID }) {
+                        currentPhotoIndex = index
+                    }
                         // 화면이 처음 나타날 때 현재 선택된 썸네일로 스크롤
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                            withAnimation(.easeInOut(duration: 0.25)) {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
                                 proxy.scrollTo(currentPhoto.objectID, anchor: .center)
                             }
                         }
                     }
             .onChange(of: currentPhoto) { newPhoto in
                         // currentPhoto가 변경될 때마다 해당 썸네일로 스크롤
-                        withAnimation(.easeInOut(duration: 0.25)) {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 1.0)) {
                             proxy.scrollTo(newPhoto.objectID, anchor: .center)
                         }
                     }
@@ -110,6 +148,11 @@ struct PhotoDetailView: View {
             impactFeedback.impactOccurred()
             
             currentPhoto = photo
+            
+            // 클릭된 사진의 인덱스로 currentPhotoIndex 업데이트
+                    if let index = photos.firstIndex(where: { $0.objectID == photo.objectID }) {
+                        currentPhotoIndex = index
+                    }
             
         } label: {
             if case .normal = thumbnailState(for: photo) {

--- a/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
@@ -66,12 +66,13 @@ struct PhotoDetailView: View {
     // MARK: - Thumbnail Scroll View
     private var thumbnailScrollView: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 3) {
+            LazyHStack(spacing: 3) {
                 ForEach(photos, id: \.objectID) { photo in
                     thumbnailItem(photo: photo)
                 }
             }
             .padding(.vertical, 14)
+            .frame(height: 105)
         }
         .background(
             Rectangle()
@@ -86,22 +87,25 @@ struct PhotoDetailView: View {
     // MARK: - Thumbnail Item
     private func thumbnailItem(photo: Photo) -> some View {
         Button {
+            let impactFeedback = UIImpactFeedbackGenerator(style: .light)
+            impactFeedback.impactOccurred()
+            
             currentPhoto = photo
             
         } label: {
             if case .normal = thumbnailState(for: photo) {
                 AsyncPhotoImage(photo: photo)
                     .clipShape(Rectangle())
-                    .frame(width: 57, height: 77)
+                    .frame(width: 57)
                 
             } else if case .selected = thumbnailState(for: photo) {
                 ZStack {
                     AsyncPhotoImage(photo: photo)
                         .clipShape(Rectangle())
-                        .frame(width: 57, height: 77)
+                        .frame(width: 57)
                     Rectangle()
                         .foregroundColor(.gray900.opacity(0.5))
-                        .frame(width: 57, height: 77)
+                        .frame(width: 57)
                     Text("now")
                         .customFont(.categoryButtonTitle)
                         .foregroundColor(.gray0)

--- a/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
+++ b/Caladium/Caladium/Views/Screen/PhotoDetailView.swift
@@ -65,22 +65,41 @@ struct PhotoDetailView: View {
     
     // MARK: - Thumbnail Scroll View
     private var thumbnailScrollView: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            LazyHStack(spacing: 3) {
-                ForEach(photos, id: \.objectID) { photo in
-                    thumbnailItem(photo: photo)
+        ScrollViewReader { proxy in
+            GeometryReader { geometry in
+            ScrollView(.horizontal, showsIndicators: false) {
+                LazyHStack(spacing: 3) {
+                    ForEach(photos, id: \.objectID) { photo in
+                        thumbnailItem(photo: photo)
+                            .id(photo.objectID)
+                    }
                 }
+                .padding(.vertical, 14)
+                .padding(.horizontal, geometry.size.width / 2 - 28.5)
+                .frame(height: 105)
             }
-            .padding(.vertical, 14)
-            .frame(height: 105)
         }
-        .background(
-            Rectangle()
-                .fill(Color.gray0)
-                .shadow(color: .gray900.opacity(0.25), radius: 1.5, x: 0, y: 2)
-                .border(Color.gray400, width: 1)
-        )
-        
+            .background(
+                Rectangle()
+                    .fill(Color.gray0)
+                    .shadow(color: .gray900.opacity(0.25), radius: 1.5, x: 0, y: 2)
+                    .border(Color.gray400, width: 1)
+            )
+            .onAppear {
+                        // 화면이 처음 나타날 때 현재 선택된 썸네일로 스크롤
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                proxy.scrollTo(currentPhoto.objectID, anchor: .center)
+                            }
+                        }
+                    }
+            .onChange(of: currentPhoto) { newPhoto in
+                        // currentPhoto가 변경될 때마다 해당 썸네일로 스크롤
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            proxy.scrollTo(newPhoto.objectID, anchor: .center)
+                        }
+                    }
+        }
         
     }
     


### PR DESCRIPTION
# 설명
사진 상세화면에 **썸네일 네비게이션 기능** 및 **스와이프 기능**을 추가했습니다.

# 변경 사항
- 프로젝트 내 사진들을 하단 썸네일로 표시
- 현재 사진 'now' 표시 및 썸네일 탭으로 전환
- 썸네일 선택 시 자동 중앙배치
- `PhotoFrame` 스와이프 제스처로 넘기기

# 영상 확인
https://github.com/user-attachments/assets/669514bc-37ff-4a53-bcb3-cdac11847d69


# 검토자에게 할 말
- 현재 iPhone SE 모델에서만 하단이 잘리는 문제가 있는데,,, 울화통 이슈로 추후 업데이트 하겠습니다.
